### PR TITLE
feature/improve-visibility-of-data-darkmode-20251024

### DIFF
--- a/pages/data.vue
+++ b/pages/data.vue
@@ -45,7 +45,7 @@
           <tbody>
             <template v-for="(row, index) in scoreSummary" :key="row.game">
               <!-- ゲーム行 -->
-              <tr class="cursor-pointer border-t border-gray-200" @click="toggleRow(index)">
+              <tr class="cursor-pointer border-t border-gray-200 dark:border-gray-700" @click="toggleRow(index)">
                 <td class="px-4 py-2">
                   <span class="ml-2 text-gray-400 text-xs">
                     {{ expandedRows.includes(index) ? "▲" : "▼" }}


### PR DESCRIPTION
data ページの視認性向上
ダークモードでの行間ボーダーの色を白→灰色に変更